### PR TITLE
asynchronous schedulable crawler jobs now working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ MANIFEST
 *.manifest
 *.spec
 
+# Sublime Text fil
+.sublime-project
+.sublime-workspace
+
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
@@ -102,3 +106,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+*.sublime-project
+
+*.sublime-workspace

--- a/Scrapple/Scrapple/__init__.py
+++ b/Scrapple/Scrapple/__init__.py
@@ -1,23 +1,24 @@
-from . import data_manager 
+from . import data_manager_schedulable 
 
 class Scrapple:
     __scrapers = set()
 
     def intialize(self):
-        print("The scrapple has been initialized")
+        print("The restartable scrapple has been initialized")
 
-    def start_scraper(self, strScraperName):
+    def start_spider_sch(self, strScraperName):
         print("Starting " + strScraperName)
-        data_manager.dataManager.start_spider(strScraperName)
+        data_manager_schedulable.dataManager.spider_sch(strScraperName)
 
-    def stop_scraper(self, strScraperName):
+    def stop_spider_sch(self, strScraperName):
         if strScraperName in self.__scrapers:
             print("Item is running. Stopping " + strScraperName)
+            data_manager_schedulable.dataManager.stop_spider_sch(strScraperName)
         else :
             print(strScraperName + " is not current running")
 
-    def run_spiders(self):
-        data_manager.dataManager.run_spiders()
+    # def run_spiders(self):
+    #     data_manager_schedulable.dataManager.run_spiders()
 
 
 scrapple = Scrapple()

--- a/Scrapple/Scrapple/__init__.py
+++ b/Scrapple/Scrapple/__init__.py
@@ -8,19 +8,19 @@ class Scrapple:
 
     def start_spider_sch(self, strScraperName):
         print("start_spider_sch> Starting " + strScraperName)
-        data_manager_schedulable.dataManager.start_spider_sch(strScraperName)
+        response = data_manager_schedulable.dataManager.start_spider_sch(strScraperName)
         self.__scrapers[strScraperName] = True
+        return response
 
     def stop_spider_sch(self, strScraperName):
         if strScraperName in self.__scrapers:
             print("Item is running. Stopping " + strScraperName)
-            data_manager_schedulable.dataManager.stop_spider_sch(strScraperName)
+            response = data_manager_schedulable.dataManager.stop_spider_sch(strScraperName)
             del(self.__scrapers[strScraperName])
         else :
-            print("stop_spider_sch> ",strScraperName + " is not current running")
+            response = "stop_spider_sch> " + strScraperName + " is not current running"
+        return response
 
-    # def run_spiders(self):
-    #     data_manager_schedulable.dataManager.run_spiders()
 
 
 scrapple = Scrapple()

--- a/Scrapple/Scrapple/__init__.py
+++ b/Scrapple/Scrapple/__init__.py
@@ -1,21 +1,23 @@
 from . import data_manager_schedulable 
 
 class Scrapple:
-    __scrapers = set()
+    __scrapers = {}
 
     def intialize(self):
         print("The restartable scrapple has been initialized")
 
     def start_spider_sch(self, strScraperName):
-        print("Starting " + strScraperName)
-        data_manager_schedulable.dataManager.spider_sch(strScraperName)
+        print("start_spider_sch> Starting " + strScraperName)
+        data_manager_schedulable.dataManager.start_spider_sch(strScraperName)
+        self.__scrapers[strScraperName] = True
 
     def stop_spider_sch(self, strScraperName):
         if strScraperName in self.__scrapers:
             print("Item is running. Stopping " + strScraperName)
             data_manager_schedulable.dataManager.stop_spider_sch(strScraperName)
+            del(self.__scrapers[strScraperName])
         else :
-            print(strScraperName + " is not current running")
+            print("stop_spider_sch> ",strScraperName + " is not current running")
 
     # def run_spiders(self):
     #     data_manager_schedulable.dataManager.run_spiders()

--- a/Scrapple/Scrapple/data_manager_schedulable.py
+++ b/Scrapple/Scrapple/data_manager_schedulable.py
@@ -12,7 +12,7 @@ import schedule
 class DataManager:
     def __init__(self):
         # [spyder_obj] is the name of the object that contains a Scrapy spider
-        # [schedule_obj] contains a schedule schedule object see https://schedule.readthedocs.io/en/stable/
+        # [schedule_obj] contains a schedule object see https://schedule.readthedocs.io/en/stable/
         self.__spiderMap = {"craigslist":
                             {"spyder_obj": craig_spyder.MySpider,
                              "schedule_title": "schedule.every(10).minutes.do(self.dummy_scrapy_job)",
@@ -50,6 +50,7 @@ class DataManager:
             print(result)
     
     def start_spider_sch(self, strSpiderName):
+        emit_status ="No info"
         if strSpiderName not in self.__activeSpiders:
             print("start_spider_sch> Added spider schedule for " + strSpiderName)
             self.__spiderMap[strSpiderName]["sch_que"] = Queue()
@@ -60,17 +61,21 @@ class DataManager:
                                         args=(self.__spiderMap[strSpiderName]["sch_que"], scheduled_job))
             self.__spiderMap[strSpiderName]["sch_proc"].start()
             self.__spiderMap[strSpiderName]["sch_que"].put("START Scrapy schedule")
-            print("start_spider_sch> START Scrapy schedule for", strSpiderName)
+            emit_status = "start_spider_sch> START Scrapy schedule for " + strSpiderName
         else:
-            print(strSpiderName, "alrede scheduled, stop first") # is this nesasry?
+            emit_status = "start_spider_sch> " + strSpiderName + " is alrede scheduled, stop to reschedule"
+        print(emit_status)
+        return emit_status
+
 
     def stop_spider_sch(self, strSpiderName): 
+        emit_status ="No info"
         print("stop_spider_sch> activeSpiders ")       
         if strSpiderName in self.__activeSpiders:
             print("stop_spider_sch> stoping schedule for ",strSpiderName)
             # this tells schedule_worker to stop running
             self.__spiderMap[strSpiderName]["sch_que"].put("STOP")
-            # the following joins up the threads of the terminating process 
+            # the following joins up the threads of the terminating process and queue
             self.__spiderMap[strSpiderName]["sch_que"].close()
             self.__spiderMap[strSpiderName]["sch_que"].join_thread()
             self.__spiderMap[strSpiderName]["sch_proc"].join()
@@ -78,9 +83,11 @@ class DataManager:
             del(self.__spiderMap[strSpiderName]["sch_proc"])
             del(self.__activeSpiders[strSpiderName])
             # everything should now be cleaned out 
-            print(strSpiderName, " schedule removed")
+            emit_status =  strSpiderName + " schedule removed"
         else:
-            print("stop_spider_sch> No schedule active for ", strSpiderName)
+            emit_status = "stop_spider_sch> No schedule active for " + strSpiderName
+        print(emit_status)
+        return emit_status
 
     def new_item_recieved(self, item):
         dataFactory.listings_setter(item)

--- a/Scrapple/Scrapple/data_manager_schedulable.py
+++ b/Scrapple/Scrapple/data_manager_schedulable.py
@@ -1,0 +1,110 @@
+# data_manager_schedulable.py
+import scrapy
+from multiprocessing import Process, Queue
+from twisted.internet import reactor
+from scrapy.crawler import CrawlerRunner
+from scrapy.utils.project import get_project_settings
+from . import pipeline
+from . import craig_spyder
+from Database import dataFactory
+
+#import multiprocessing
+import schedule
+import time
+
+
+class DataManager:
+    def __init__(self):
+        self.__spiderMap = { "craigslist": 
+                             {"spyder": craig_spyder.MySpider,
+                             "schedule_title": "schedule.every(10).minutes.do(dummy_scrapy_job)",
+                             "schedule_obj": schedule.every(10).minutes.do(dummy_scrapy_job),
+                             "sch_proc": None,
+                             "sch_que": None}
+                            }
+        # { "craigslist": craig_spyder.MySpider}
+        pipeline.newItemCallback.set_callback(self.new_item_recieved)
+        print("Data Manager started")
+        self.__activeSpiders = {}
+        
+    @staticmethod
+    def run_spider_in_thread(queue, spider):
+        try:
+            #runner = spider.CrawlerRunner()
+            runner = CrawlerRunner(get_project_settings())
+            deferred = runner.crawl(spider)
+            deferred.addBoth(lambda _: reactor.stop())
+            reactor.run()
+            queue.put(None)
+        except Exception as e:
+            queue.put(e)
+
+
+    def start_spider(self, strSpiderName):
+        print("DataManager.start_spider")
+        q = Queue()
+        spider = self.__spiderMap[strSpiderName];
+        thread = Process(target=self.run_spider_in_thread, args=(q,spider))
+        thread.start()
+        result = q.get()
+        thread.join()
+        
+        if result is not None:
+            print(result)
+
+    
+    # def run_spiders(self):
+    #     # for spider, process in self.__activeSpiders.items():
+    #     #     runner.start()
+    #     #     process.stop()
+    #     d = self.__runner.join()
+    #     d.addBoth(lambda _: reactor.stop())
+    #     reactor.run() # the script will block here until all crawling jobs are finished
+    #     del self.__runner
+
+
+
+    def start_spider_sch(self, strSpiderName):
+        # in start_schedule methed
+        print("Added spider schedule for" + strSpiderName)
+        # set sch_que this in __spiderMap
+        self.__spiderMap[strSpiderName]["sch_que"] = multiprocessing.Queue()
+        self.__activeSpiders[strSpiderName] = "STARTED"
+        # get scheduled_job this from __spiderMap
+        scheduled_job = self.__spiderMap[strSpiderName]["schedule_obj"] #schedule.every(2).seconds.do(dummy_scrapy_job)
+        # set sch_proc in __spiderMap
+        self.__spiderMap[strSpiderName]["sch_proc"] = multiprocessing.Process(target=schedule_worker, args=(sch_que, scheduled_job))
+        self.__spiderMap[strSpiderName]["sch_proc"].start()
+        self.__spiderMap[strSpiderName]["sch_que"].put("START Scrapy schedule")
+        time.sleep(6)
+
+
+    def stop_spider_sch(self, strSpiderName):
+        print("stop_spider depricated")
+        if strSpiderName in self.__activeSpiders:
+            self.__spiderMap[strSpiderName]["sch_que"].put("STOP")
+            self.__spiderMap[strSpiderName]["sch_que"].close()
+            self.__spiderMap[strSpiderName]["sch_que"].join_thread()
+            self.__spiderMap[strSpiderName]["sch_proc"].join()
+            # kill sch_proc Process
+            del(self.__spiderMap[strSpiderName]["sch_proc"])
+            del self.__activeSpiders[strSpiderName]
+
+    def new_item_recieved(self, item):        
+        dataFactory.listings_setter( item )
+
+    def dummy_scrapy_job(self):
+        print("I'm working at Scrapying...")
+
+    def schedule_worker(self, sch_q, scheduled_job):
+        scheduled_job
+        q_mesg = sch_q.get()
+        print ("q_mesg:",q_mesg)
+        while q_mesg != "STOP":
+            schedule.run_pending()
+            if not sch_q.empty():
+                q_mesg = sch_q.get()
+                print ("q_mesg:",q_mesg)        
+            time.sleep(1)
+
+dataManager = DataManager()

--- a/Scrapple/Scrapple/data_manager_schedulable.py
+++ b/Scrapple/Scrapple/data_manager_schedulable.py
@@ -1,5 +1,4 @@
 # data_manager_schedulable.py
-#import scrapy
 from multiprocessing import Process, Queue
 from twisted.internet import reactor
 from scrapy.crawler import CrawlerRunner

--- a/Scrapple/Server/data_views.py
+++ b/Scrapple/Server/data_views.py
@@ -21,7 +21,6 @@ def listings_handler():
             "You must provide an rid or a start (dfrom) and end date (dto) "
             "in the form YYYY-mm-dd.",
             status=401))
-
     pagesize = request.args.get('pagesize', None)
     if pagesize:
         pagesize = int(pagesize)
@@ -30,15 +29,24 @@ def listings_handler():
     return emit_sjson
 
 
-@app.route('/start_scraper', methods=["POST"])
-def start_scraper():
+@app.route('/start_spider_sch', methods=["POST"])
+def start_spider_sch():
     scraper_name = request.args.get('scraper')
-
     if scraper_name:
-        scrapple.start_scraper(scraper_name)
-        scrapple.run_spiders()
+        scrapple.start_spider_sch(scraper_name)
+        #scrapple.run_spiders()
         print("starting scraper " + scraper_name)
         return "success"
     else:
         abort(Response("Missing parameter: scraper", status=401))
 
+
+@app.route('/stop_spider_sch', methods=["POST"])
+def stop_spider_sch():
+    scraper_name = request.args.get('scraper')
+    if scraper_name:
+        scrapple.stop_spider_sch(scraper_name)
+        print("stop scraper " + scraper_name)
+        return "success"
+    else:
+        abort(Response("Missing parameter: scraper", status=401))

--- a/Scrapple/Server/data_views.py
+++ b/Scrapple/Server/data_views.py
@@ -31,22 +31,23 @@ def listings_handler():
 
 @app.route('/start_spider_sch', methods=["POST"])
 def start_spider_sch():
+    status_msg = "no msg"
     scraper_name = request.args.get('scraper')
     if scraper_name:
-        scrapple.start_spider_sch(scraper_name)
-        #scrapple.run_spiders()
         print("start_spider_sch>Try to start scrapy schedule for " + scraper_name)
-        return "success?"
+        status_msg = scrapple.start_spider_sch(scraper_name)
+        return status_msg
     else:
         abort(Response("Missing parameter: scraper", status=401))
 
 
 @app.route('/stop_spider_sch', methods=["POST"])
 def stop_spider_sch():
+    status_msg = "no msg"
     scraper_name = request.args.get('scraper')
     if scraper_name:
         print("stop_spider_sch> Try to stop scraper " + scraper_name)
-        scrapple.stop_spider_sch(scraper_name)
-        return "success?"
+        status_msg = scrapple.stop_spider_sch(scraper_name)
+        return status_msg
     else:
         abort(Response("Missing parameter: scraper", status=401))

--- a/Scrapple/Server/data_views.py
+++ b/Scrapple/Server/data_views.py
@@ -35,8 +35,8 @@ def start_spider_sch():
     if scraper_name:
         scrapple.start_spider_sch(scraper_name)
         #scrapple.run_spiders()
-        print("starting scraper " + scraper_name)
-        return "success"
+        print("start_spider_sch>Try to start scrapy schedule for " + scraper_name)
+        return "success?"
     else:
         abort(Response("Missing parameter: scraper", status=401))
 
@@ -45,8 +45,8 @@ def start_spider_sch():
 def stop_spider_sch():
     scraper_name = request.args.get('scraper')
     if scraper_name:
+        print("stop_spider_sch> Try to stop scraper " + scraper_name)
         scrapple.stop_spider_sch(scraper_name)
-        print("stop scraper " + scraper_name)
-        return "success"
+        return "success?"
     else:
         abort(Response("Missing parameter: scraper", status=401))


### PR DESCRIPTION
I have parallel manageable schedules running which control the crawler which could be multiple crawlers. Each crawler gets its own separate schedule process which can be started or stopped independently my name.

I changed the name of the endpoints the following starts the scheduler
http://localhost:5555/start_spider_sch?scraper=craigslist

this terminates the scheduler
http://localhost:5555/stop_spider_sch?scraper=craigslist

However, it turns out we do have the listing_id duplication problem I thought this might occur will need to come up with a fix, I favor keeping a list of listing_id setpoints and having the crawlers themselves use this to filter out already processed ids.